### PR TITLE
her2 typo

### DIFF
--- a/cxxblas/level2/her2.tcc
+++ b/cxxblas/level2/her2.tcc
@@ -144,7 +144,7 @@ her2(StorageOrder order,   StorageUpLo upLo,
 {
     CXXBLAS_DEBUG_OUT("[" BLAS_IMPL "] cblas_cher2");
 
-    cblas_che2r(CBLAS::getCblasType(order), CBLAS::getCblasType(upLo),
+    cblas_cher2(CBLAS::getCblasType(order), CBLAS::getCblasType(upLo),
                 n,
                 reinterpret_cast<const float *>(&alpha),
                 reinterpret_cast<const float *>(x), incX,


### PR DESCRIPTION
Found when creating shared flens-blas library with openblas backing.
