### PR TITLE
BUG: asum(GeMatrix)

### DIFF
--- a/flens/blas/level1/asum.tcc
+++ b/flens/blas/level1/asum.tcc
@@ -77,13 +77,14 @@ asum(const GeMatrix<MA> &A, T &absoluteSum)
 
     const Underscore<IndexType>  _;
 
+    absoluteSum = T();
     if (A.order()==ColMajor) {
         for (IndexType j=A.firstCol(); j<=A.lastCol(); ++j) {
-            asum(A(_,j), absoluteSum);
+            absoluteSum += asum(A(_,j));
         }
     } else {
         for (IndexType i=A.firstRow(); i<=A.lastRow(); ++i) {
-            asum(A(i,_), absoluteSum);
+            absoluteSum += asum(A(i,_));
         }
     }
 }

--- a/flens/blas/level1extensions/asum1.tcc
+++ b/flens/blas/level1extensions/asum1.tcc
@@ -77,13 +77,14 @@ asum1(const GeMatrix<MA> &A, T &absoluteSum)
 
     const Underscore<IndexType>  _;
 
+    absoluteSum = T();
     if (A.order()==ColMajor) {
         for (IndexType j=A.firstCol(); j<=A.lastCol(); ++j) {
-            asum1(A(_,j), absoluteSum);
+            absoluteSum += asum1(A(_,j));
         }
     } else {
         for (IndexType i=A.firstRow(); i<=A.lastRow(); ++i) {
-            asum1(A(i,_), absoluteSum);
+            absoluteSum += asum1(A(i,_));
         }
     }
 }


### PR DESCRIPTION
Found when working with Frobenius norms on matrices. The asum function sets the output parameter rather than accumulates into it.

It's unclear to me what the purpose of asum1/iamax1 is in level1extensions. Should these be removed?
