### PR TITLE
proposed fix for compile error on GCC 5

### DIFF
--- a/flens/flens.cxx
+++ b/flens/flens.cxx
@@ -42,7 +42,7 @@
 #elif __clang__
 //#    define STD_HACK
 #elif __GNUC__
-     static_assert(__GNUG__>=4 && __GNUC_MINOR__>=7,
+     static_assert((__GNUG__==4 && __GNUC_MINOR__>=7) || __GNUG__>=5,
                    "GNU GCC Version 4.7 or higher required!");
 #    define GCC_HACK
 #    define INCLUDE_TYPE_TRAITS


### PR DESCRIPTION
Static assert will fail on GCC 5.0 because `__GNUC_MINOR__ == 0`
