### PR TITLE
RValue Reference Templated Engine Constructors

### DIFF
--- a/cxxstd/type_traits.h
+++ b/cxxstd/type_traits.h
@@ -1,5 +1,5 @@
-#ifndef CXXSTD_STRING_H
-#define CXXSTD_STRING_H 1
+#ifndef CXXSTD_TYPE_TRAITS_H
+#define CXXSTD_TYPE_TRAITS_H 1
 
 #include <type_traits>
 

--- a/flens/matrixtypes/general/impl/diagmatrix.h
+++ b/flens/matrixtypes/general/impl/diagmatrix.h
@@ -99,6 +99,10 @@ class DiagMatrix
         template <typename RHS>
         DiagMatrix(DiagMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            DiagMatrix(DiagMatrix<RHS> &&rhs);
+
         template <typename RHS>
         DiagMatrix(const DenseVector<RHS> &rhs);
 

--- a/flens/matrixtypes/general/impl/diagmatrix.tcc
+++ b/flens/matrixtypes/general/impl/diagmatrix.tcc
@@ -47,7 +47,7 @@ DiagMatrix<FS>::DiagMatrix()
 
 template <typename FS>
 DiagMatrix<FS>::DiagMatrix(IndexType dim, IndexType firstIndex)
-      : engine_(dim, firstIndex)
+    : engine_(dim, firstIndex)
 {
 }
 
@@ -59,7 +59,7 @@ DiagMatrix<FS>::DiagMatrix(const Engine &engine)
 
 template <typename FS>
 DiagMatrix<FS>::DiagMatrix(const DiagMatrix &rhs)
-    : GeneralMatrix<DiagMatrix<FS> >(), engine_(rhs.engine())
+    : engine_(rhs.engine())
 {
 }
 
@@ -73,6 +73,13 @@ DiagMatrix<FS>::DiagMatrix(const DiagMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 DiagMatrix<FS>::DiagMatrix(DiagMatrix<RHS> &rhs)
+    : engine_(rhs.engine())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+DiagMatrix<FS>::DiagMatrix(DiagMatrix<RHS> &&rhs)
     : engine_(rhs.engine())
 {
 }

--- a/flens/matrixtypes/general/impl/gbmatrix.h
+++ b/flens/matrixtypes/general/impl/gbmatrix.h
@@ -107,6 +107,10 @@ class GbMatrix
         template <typename RHS>
             GbMatrix(GbMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            GbMatrix(GbMatrix<RHS> &&rhs);
+
         template <typename RHS>
             GbMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/general/impl/gbmatrix.tcc
+++ b/flens/matrixtypes/general/impl/gbmatrix.tcc
@@ -65,8 +65,7 @@ GbMatrix<FS>::GbMatrix(const Engine &engine)
 
 template <typename FS>
 GbMatrix<FS>::GbMatrix(const GbMatrix &rhs)
-    : GeneralMatrix<GbMatrix<FS> >(),
-      engine_(rhs.engine())
+    : engine_(rhs.engine())
 {
 }
 
@@ -80,6 +79,13 @@ GbMatrix<FS>::GbMatrix(const GbMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 GbMatrix<FS>::GbMatrix(GbMatrix<RHS> &rhs)
+    : engine_(rhs.engine())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+GbMatrix<FS>::GbMatrix(GbMatrix<RHS> &&rhs)
     : engine_(rhs.engine())
 {
 }

--- a/flens/matrixtypes/general/impl/gematrix.h
+++ b/flens/matrixtypes/general/impl/gematrix.h
@@ -127,6 +127,10 @@ class GeMatrix
         template <typename RHS>
             GeMatrix(GeMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            GeMatrix(GeMatrix<RHS> &&rhs);
+
         template <typename RHS>
             GeMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/general/impl/gematrix.tcc
+++ b/flens/matrixtypes/general/impl/gematrix.tcc
@@ -85,7 +85,7 @@ GeMatrix<FS>::GeMatrix(const Engine &engine)
 
 template <typename FS>
 GeMatrix<FS>::GeMatrix(const GeMatrix &rhs)
-    : GeneralMatrix<GeMatrix>(), engine_(rhs.engine_)
+    : engine_(rhs.engine_)
 {
 }
 
@@ -99,6 +99,13 @@ GeMatrix<FS>::GeMatrix(const GeMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 GeMatrix<FS>::GeMatrix(GeMatrix<RHS> &rhs)
+    : engine_(rhs.engine())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+GeMatrix<FS>::GeMatrix(GeMatrix<RHS> &&rhs)
     : engine_(rhs.engine())
 {
 }

--- a/flens/matrixtypes/general/impl/getinymatrix.h
+++ b/flens/matrixtypes/general/impl/getinymatrix.h
@@ -58,6 +58,10 @@ class GeTinyMatrix
         template <typename RHS>
             GeTinyMatrix(GeTinyMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<TFS,RHS>::value, void>::Type>
+            GeTinyMatrix(GeTinyMatrix<RHS> &&rhs);
+
         template <typename RHS>
             GeTinyMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/general/impl/getinymatrix.tcc
+++ b/flens/matrixtypes/general/impl/getinymatrix.tcc
@@ -69,6 +69,13 @@ GeTinyMatrix<TFS>::GeTinyMatrix(GeTinyMatrix<RHS> &rhs)
 }
 
 template <typename TFS>
+template <typename RHS, class>
+GeTinyMatrix<TFS>::GeTinyMatrix(GeTinyMatrix<RHS> &&rhs)
+    : engine_(rhs.engine)
+{
+}
+
+template <typename TFS>
 template <typename RHS>
 GeTinyMatrix<TFS>::GeTinyMatrix(const Matrix<RHS> &rhs)
 {

--- a/flens/matrixtypes/hermitian/impl/hbmatrix.h
+++ b/flens/matrixtypes/hermitian/impl/hbmatrix.h
@@ -112,6 +112,10 @@ class HbMatrix
         template <typename RHS>
             HbMatrix(HbMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            HbMatrix(HbMatrix<RHS> &&rhs);
+
         template <typename RHS>
             HbMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/hermitian/impl/hbmatrix.tcc
+++ b/flens/matrixtypes/hermitian/impl/hbmatrix.tcc
@@ -62,25 +62,28 @@ HbMatrix<FS>::HbMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename FS>
 HbMatrix<FS>::HbMatrix(const HbMatrix &rhs)
-    : HermitianMatrix<HbMatrix<FS> >(),
-      engine_(rhs.engine()),
-      upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
 template <typename FS>
 template <typename RHS>
 HbMatrix<FS>::HbMatrix(const HbMatrix<RHS> &rhs)
-    : engine_(rhs.engine()),
-      upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
 template <typename FS>
 template <typename RHS>
 HbMatrix<FS>::HbMatrix(HbMatrix<RHS> &rhs)
-    : engine_(rhs.engine()),
-      upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+HbMatrix<FS>::HbMatrix(HbMatrix<RHS> &&rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 

--- a/flens/matrixtypes/hermitian/impl/hematrix.h
+++ b/flens/matrixtypes/hermitian/impl/hematrix.h
@@ -112,6 +112,10 @@ class HeMatrix
         template <typename RHS>
             HeMatrix(HeMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            HeMatrix(HeMatrix<RHS> &&rhs);
+
         template <typename RHS>
             HeMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/hermitian/impl/hematrix.tcc
+++ b/flens/matrixtypes/hermitian/impl/hematrix.tcc
@@ -78,8 +78,7 @@ HeMatrix<FS>::HeMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename FS>
 HeMatrix<FS>::HeMatrix(const HeMatrix &rhs)
-    : HermitianMatrix<HeMatrix<FS> >(),
-      engine_(rhs.engine()), upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
@@ -93,6 +92,13 @@ HeMatrix<FS>::HeMatrix(const HeMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 HeMatrix<FS>::HeMatrix(HeMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+HeMatrix<FS>::HeMatrix(HeMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }

--- a/flens/matrixtypes/hermitian/impl/hpmatrix.h
+++ b/flens/matrixtypes/hermitian/impl/hpmatrix.h
@@ -99,6 +99,10 @@ class HpMatrix
         template <typename RHS>
             HpMatrix(HpMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<PS,RHS>::value, void>::Type>
+            HpMatrix(HpMatrix<RHS> &&rhs);
+
         template <typename RHS>
             HpMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/hermitian/impl/hpmatrix.tcc
+++ b/flens/matrixtypes/hermitian/impl/hpmatrix.tcc
@@ -59,8 +59,7 @@ HpMatrix<PS>::HpMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename PS>
 HpMatrix<PS>::HpMatrix(const HpMatrix &rhs)
-    : HermitianMatrix<HpMatrix<PS> >(),
-      engine_(rhs.engine()), upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
@@ -74,6 +73,13 @@ HpMatrix<PS>::HpMatrix(const HpMatrix<RHS> &rhs)
 template <typename PS>
 template <typename RHS>
 HpMatrix<PS>::HpMatrix(HpMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename PS>
+template <typename RHS, class>
+HpMatrix<PS>::HpMatrix(HpMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }

--- a/flens/matrixtypes/symmetric/impl/sbmatrix.h
+++ b/flens/matrixtypes/symmetric/impl/sbmatrix.h
@@ -113,6 +113,10 @@ class SbMatrix
         template <typename RHS>
             SbMatrix(SbMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            SbMatrix(SbMatrix<RHS> &&rhs);
+
         // -- operators --------------------------------------------------------
 
         SbMatrix &

--- a/flens/matrixtypes/symmetric/impl/sbmatrix.tcc
+++ b/flens/matrixtypes/symmetric/impl/sbmatrix.tcc
@@ -65,7 +65,7 @@ SbMatrix<FS>::SbMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename FS>
 SbMatrix<FS>::SbMatrix(const SbMatrix &rhs)
-    : SymmetricMatrix<SbMatrix<FS> >(), engine_(rhs.engine()), upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
@@ -79,6 +79,13 @@ SbMatrix<FS>::SbMatrix(const SbMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 SbMatrix<FS>::SbMatrix(SbMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+SbMatrix<FS>::SbMatrix(SbMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }

--- a/flens/matrixtypes/symmetric/impl/spmatrix.h
+++ b/flens/matrixtypes/symmetric/impl/spmatrix.h
@@ -100,6 +100,10 @@ class SpMatrix
         template <typename RHS>
             SpMatrix(SpMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<PS,RHS>::value, void>::Type>
+            SpMatrix(SpMatrix<RHS> &&rhs);
+
         template <typename RHS>
             SpMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/symmetric/impl/spmatrix.tcc
+++ b/flens/matrixtypes/symmetric/impl/spmatrix.tcc
@@ -56,7 +56,7 @@ SpMatrix<PS>::SpMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename PS>
 SpMatrix<PS>::SpMatrix(const SpMatrix &rhs)
-    : SymmetricMatrix<SpMatrix<PS> >(), engine_(rhs.engine()), upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
@@ -70,6 +70,13 @@ SpMatrix<PS>::SpMatrix(const SpMatrix<RHS> &rhs)
 template <typename PS>
 template <typename RHS>
 SpMatrix<PS>::SpMatrix(SpMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename PS>
+template <typename RHS, class>
+SpMatrix<PS>::SpMatrix(SpMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }

--- a/flens/matrixtypes/symmetric/impl/symatrix.h
+++ b/flens/matrixtypes/symmetric/impl/symatrix.h
@@ -113,6 +113,10 @@ class SyMatrix
         template <typename RHS>
             SyMatrix(SyMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            SyMatrix(SyMatrix<RHS> &&rhs);
+
         template <typename RHS>
             SyMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/symmetric/impl/symatrix.tcc
+++ b/flens/matrixtypes/symmetric/impl/symatrix.tcc
@@ -78,8 +78,7 @@ SyMatrix<FS>::SyMatrix(const Engine &engine, StorageUpLo upLo)
 
 template <typename FS>
 SyMatrix<FS>::SyMatrix(const SyMatrix &rhs)
-    : SymmetricMatrix<SyMatrix<FS> >(),
-      engine_(rhs.engine()), upLo_(rhs.upLo())
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }
 
@@ -93,6 +92,13 @@ SyMatrix<FS>::SyMatrix(const SyMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 SyMatrix<FS>::SyMatrix(SyMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+SyMatrix<FS>::SyMatrix(SyMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo())
 {
 }

--- a/flens/matrixtypes/triangular/impl/tbmatrix.h
+++ b/flens/matrixtypes/triangular/impl/tbmatrix.h
@@ -105,6 +105,10 @@ class TbMatrix
         template <typename RHS>
             TbMatrix(TbMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            TbMatrix(TbMatrix<RHS> &&rhs);
+
         template <typename RHS>
             TbMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/triangular/impl/tbmatrix.tcc
+++ b/flens/matrixtypes/triangular/impl/tbmatrix.tcc
@@ -59,8 +59,7 @@ TbMatrix<FS>::TbMatrix(const Engine &engine, StorageUpLo upLo, Diag diag)
 
 template <typename FS>
 TbMatrix<FS>::TbMatrix(const TbMatrix &rhs)
-    : TriangularMatrix<TbMatrix<FS> >(),
-      engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
+    : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
 {
 }
 
@@ -74,6 +73,13 @@ TbMatrix<FS>::TbMatrix(const TbMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 TbMatrix<FS>::TbMatrix(TbMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+TbMatrix<FS>::TbMatrix(TbMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
 {
 }

--- a/flens/matrixtypes/triangular/impl/tpmatrix.h
+++ b/flens/matrixtypes/triangular/impl/tpmatrix.h
@@ -99,6 +99,10 @@ class TpMatrix
         template <typename RHS>
             TpMatrix(TpMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<PS,RHS>::value, void>::Type>
+            TpMatrix(TpMatrix<RHS> &&rhs);
+
         template <typename RHS>
             TpMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/triangular/impl/tpmatrix.tcc
+++ b/flens/matrixtypes/triangular/impl/tpmatrix.tcc
@@ -59,8 +59,7 @@ TpMatrix<PS>::TpMatrix(const Engine &engine, StorageUpLo upLo, Diag diag)
 
 template <typename PS>
 TpMatrix<PS>::TpMatrix(const TpMatrix &rhs)
-    : TriangularMatrix<TpMatrix<PS> >(),
-      engine_(rhs.engine()), upLo_(upLo), diag_(rhs.diag())
+    : engine_(rhs.engine()), upLo_(upLo), diag_(rhs.diag())
 {
 }
 
@@ -74,6 +73,13 @@ TpMatrix<PS>::TpMatrix(const TpMatrix<RHS> &rhs)
 template <typename PS>
 template <typename RHS>
 TpMatrix<PS>::TpMatrix(TpMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(upLo), diag_(rhs.diag())
+{
+}
+
+template <typename PS>
+template <typename RHS, class>
+TpMatrix<PS>::TpMatrix(TpMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(upLo), diag_(rhs.diag())
 {
 }

--- a/flens/matrixtypes/triangular/impl/trmatrix.h
+++ b/flens/matrixtypes/triangular/impl/trmatrix.h
@@ -123,6 +123,10 @@ class TrMatrix
         template <typename RHS>
             TrMatrix(TrMatrix<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<FS,RHS>::value, void>::Type>
+            TrMatrix(TrMatrix<RHS> &&rhs);
+
         template <typename RHS>
             TrMatrix(const Matrix<RHS> &rhs);
 

--- a/flens/matrixtypes/triangular/impl/trmatrix.tcc
+++ b/flens/matrixtypes/triangular/impl/trmatrix.tcc
@@ -73,8 +73,7 @@ TrMatrix<FS>::TrMatrix(const Engine &engine, StorageUpLo upLo, Diag diag)
 
 template <typename FS>
 TrMatrix<FS>::TrMatrix(const TrMatrix &rhs)
-    : TriangularMatrix<TrMatrix<FS> >(),
-      engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
+    : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
 {
 }
 
@@ -88,6 +87,13 @@ TrMatrix<FS>::TrMatrix(const TrMatrix<RHS> &rhs)
 template <typename FS>
 template <typename RHS>
 TrMatrix<FS>::TrMatrix(TrMatrix<RHS> &rhs)
+    : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
+{
+}
+
+template <typename FS>
+template <typename RHS, class>
+TrMatrix<FS>::TrMatrix(TrMatrix<RHS> &&rhs)
     : engine_(rhs.engine()), upLo_(rhs.upLo()), diag_(rhs.diag())
 {
 }

--- a/flens/vectortypes/impl/densevector.h
+++ b/flens/vectortypes/impl/densevector.h
@@ -97,7 +97,8 @@ class DenseVector
         template <typename RHS>
             DenseVector(DenseVector<RHS> &rhs);
 
-        template <typename RHS>
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<A,RHS>::value, void>::Type>
             DenseVector(DenseVector<RHS> &&rhs);
 
         template <typename RHS>

--- a/flens/vectortypes/impl/densevector.tcc
+++ b/flens/vectortypes/impl/densevector.tcc
@@ -79,7 +79,7 @@ DenseVector<A>::DenseVector(const Engine &engine, bool reverse)
 
 template <typename A>
 DenseVector<A>::DenseVector(const DenseVector &rhs)
-    : Vector<DenseVector>(), array_(rhs.array_), stride_(rhs.stride_)
+    : array_(rhs.array_), stride_(rhs.stride_)
 {
 }
 
@@ -98,7 +98,7 @@ DenseVector<A>::DenseVector(DenseVector<RHS> &rhs)
 }
 
 template <typename A>
-template <typename RHS>
+template <typename RHS, class>
 DenseVector<A>::DenseVector(DenseVector<RHS> &&rhs)
     : array_(rhs.engine()), stride_(array_.stride())
 {

--- a/flens/vectortypes/impl/tinyvector.h
+++ b/flens/vectortypes/impl/tinyvector.h
@@ -58,6 +58,10 @@ class TinyVector
         template <typename RHS>
             TinyVector(TinyVector<RHS> &rhs);
 
+        template <typename RHS,
+                  class = typename RestrictTo<!IsSame<TA,RHS>::value, void>::Type>
+            TinyVector(TinyVector<RHS> &&rhs);
+
         template <typename RHS>
             TinyVector(const Vector<RHS> &rhs);
 

--- a/flens/vectortypes/impl/tinyvector.tcc
+++ b/flens/vectortypes/impl/tinyvector.tcc
@@ -68,6 +68,13 @@ TinyVector<TA>::TinyVector(TinyVector<RHS> &rhs)
 }
 
 template <typename TA>
+template <typename RHS, class>
+TinyVector<TA>::TinyVector(TinyVector<RHS> &&rhs)
+    : array_(rhs.engine())
+{
+}
+
+template <typename TA>
 template <typename RHS>
 TinyVector<TA>::TinyVector(const Vector<RHS> &rhs)
 {


### PR DESCRIPTION
This patch completes and repairs the constructors added in the mailing list thread:
https://imap.uni-ulm.de/lists/arc/flens/2015-02/msg00000.html
and uses the improved pattern in:
https://imap.uni-ulm.de/lists/arc/flens/2015-03/msg00000.html
to allow elision and avoid redundant deep copies.

This patch also cleans up the consistency of the constructors:
- Empty base class constructors do not need to be called.
- Text alignment, prefer single-line initializer lists.
