### PR TITLE
Separate complex and real wrappers for ev method.

### DIFF
--- a/flens/lapack/ge/ev.h
+++ b/flens/lapack/ge/ev.h
@@ -160,12 +160,19 @@ template <typename MA, typename VW, typename MVL, typename MVR>
 //
 template <typename MA, typename VW>
     typename RestrictTo<(IsComplexGeMatrix<MA>::value
-                      && IsComplexDenseVector<VW>::value)
-             ||         (IsRealGeMatrix<MA>::value
-                      && IsRealDenseVector<VW>::value),
+                      && IsComplexDenseVector<VW>::value),
              typename RemoveRef<MA>::Type::IndexType>::Type
     ev(MA       &&A,
        VW       &&w);
+
+template <typename MA, typename VWR, typename VWI>
+    typename RestrictTo<(IsRealGeMatrix<MA>::value
+                      && IsRealDenseVector<VWR>::value
+                      && IsRealDenseVector<VWI>::value),
+             typename RemoveRef<MA>::Type::IndexType>::Type
+    ev(MA       &&A,
+       VWR      &&wr,
+       VWI      &&wi);
 
 } } // namespace lapack, flens
 

--- a/flens/lapack/ge/ev.tcc
+++ b/flens/lapack/ge/ev.tcc
@@ -1360,14 +1360,24 @@ ev(bool     computeVL,
 
 template <typename MA, typename VW>
 typename RestrictTo<(IsComplexGeMatrix<MA>::value
-                  && IsComplexDenseVector<VW>::value)
-         ||         (IsRealGeMatrix<MA>::value
-                  && IsRealDenseVector<VW>::value),
+                  && IsComplexDenseVector<VW>::value),
          typename RemoveRef<MA>::Type::IndexType>::Type
 ev(MA       &&A,
    VW       &&w)
 {
     return ev(false, false, A, w, A, A);
+}
+
+template <typename MA, typename VWR, typename VWI>
+typename RestrictTo<(IsRealGeMatrix<MA>::value
+                  && IsRealDenseVector<VWR>::value
+                  && IsRealDenseVector<VWI>::value),
+         typename RemoveRef<MA>::Type::IndexType>::Type
+ev(MA       &&A,
+   VWR      &&wr,
+   VWI      &&wi)
+{
+    return ev(false, false, A, wr, wi, A, A);
 }
 
 } } // namespace lapack, flens


### PR DESCRIPTION
In accordance with our previous discussion concerning issu #13, here is the patch adding two wrappers for ev method. 

Comment:
- Real wrapper still deals with an imaginary part since even if A is a
  real matrix its eigenvalues can be complex.

Cheers
