### PR TITLE
license typo: "funn" => "form"

### DIFF
--- a/cxxlapack/interface/unmtr.tcc
+++ b/cxxlapack/interface/unmtr.tcc
@@ -3,13 +3,13 @@
  *
  *   All rights reserved.
  *
- *   Redistribution and use in source and binary funns, with or without
+ *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
  *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- *   2) Redistributions in binary funn must reproduce the above copyright
+ *   2) Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in
  *      the documentation and/or other materials provided with the
  *      distribution.


### PR DESCRIPTION
Fix what appears to be a typographical error in the license text.